### PR TITLE
VAD機能の実装

### DIFF
--- a/PredicTalk/PredicTalk/Sources/SpeechRecognizer.swift
+++ b/PredicTalk/PredicTalk/Sources/SpeechRecognizer.swift
@@ -79,7 +79,6 @@ class SpeechRecognizer: ObservableObject {
                 self.request = request
 
                 self.task = recognizer.recognitionTask(with: request) { result, error in
-                    self.resetTimeoutTimer()
                     let receivedFinalResult = result?.isFinal ?? false
                     let receivedError = error != nil
 
@@ -89,6 +88,7 @@ class SpeechRecognizer: ObservableObject {
                     }
 
                     if let result = result {
+                        self.resetTimeoutTimer()
                         self.isSilent = false
                         self.speak(result.bestTranscription.formattedString)
                     }
@@ -102,7 +102,7 @@ class SpeechRecognizer: ObservableObject {
     
     func resetTimeoutTimer() {
             timeoutTimer?.invalidate()
-            timeoutTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: false) { timer in
+            timeoutTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: false) { _ in
                     self.isSilent = true
                 
             }


### PR DESCRIPTION
## 概要
<!-- 関連するIssue-->
<!-- 経緯・背景・どんなことを行うのか--> 沈黙を認識し、APIリクエストの回数を減らす。

## 実装
<!-- どういうアプローチで変更を行ったか-->
音声認識のtaskにTimerを実装し、taskが実行されるたびにTimerがリセットされるようになっている。
`timeoutTimer?.invalidate()`で以前のものは破棄され、新たに別のTimerが設定される。
`isSilent`について、taskが実行されるたびに一度`false`になり、Timerによってのみ`true`に変化するようにしている。

## スクリーンショット（あれば）
<!--UIの変更があれば、この形式で貼り付けてください→<img width=300 src="url">-->

## 備考
<!-- 実装中に発見した仕様など、共有しておきたいこと-->
SpeechRecognizerの仕様として、`stopTranscribing()`の後に最終結果のtaskが実行される。つまり、画面をタップした後にtaskがFinalResultを出力する。

問題点として、`reset()`の後に実行される原因をまだ特定できていない。