### PR TITLE
訂正モードに終了判定を実装

### DIFF
--- a/PredicTalk/PredicTalk/Resources/Correct.md
+++ b/PredicTalk/PredicTalk/Resources/Correct.md
@@ -9,6 +9,7 @@
 
 # Constrain
 - Output is as short as possible
+- Add '$' to the end of Output only if Input is complete
 
 ## Examples
 - [Input] I study a lot machine learning [Output] I study machine learning a lot

--- a/PredicTalk/PredicTalk/View/ARModeView.swift
+++ b/PredicTalk/PredicTalk/View/ARModeView.swift
@@ -37,12 +37,17 @@ struct ARModeView: View {
                 if !transcription.isEmpty {
                     Task {
                         do {
-                            let newPrediction: String
+                            var newPrediction: String
                             switch setting.apiMode {
                             case .predict:
                                 newPrediction = try await APIRequest.shared.predict(sentence: transcription)
                             case .correct:
                                 newPrediction = try await APIRequest.shared.correct(sentence: transcription)
+                                if newPrediction.contains("$") {
+                                    newPrediction.removeAll(where:{ $0 == "$"})
+                                    speechRecognizer.stopTranscribing()
+                                    speechRecognizer.transcribe()
+                                }
                             }
                             
                             if setting.selectedLanguage == .japanese && setting.convertToHiragana {

--- a/PredicTalk/PredicTalk/View/HomeView.swift
+++ b/PredicTalk/PredicTalk/View/HomeView.swift
@@ -160,12 +160,17 @@ struct HomeView: View {
                     if !transcription.isEmpty {
                         Task {
                             do {
-                                let newPrediction: String
+                                var newPrediction: String
                                 switch setting.apiMode {
                                 case .predict:
                                     newPrediction = try await APIRequest.shared.predict(sentence: transcription)
                                 case .correct:
                                     newPrediction = try await APIRequest.shared.correct(sentence: transcription)
+                                    if newPrediction.contains("$") {
+                                        newPrediction.removeAll(where:{ $0 == "$"})
+                                        speechRecognizer.stopTranscribing()
+                                        speechRecognizer.transcribe()
+                                    }
                                 }
                                 
                                 if setting.selectedLanguage == .japanese && setting.convertToHiragana {


### PR DESCRIPTION
## 概要
<!-- 関連するIssue-->
<!-- 経緯・背景・どんなことを行うのか-->
訂正モードにおいて、訂正済みのtranscriptが残り続ける問題を解決。
## 実装
<!-- どういうアプローチで変更を行ったか-->
gpt-APIにInputの終了を判定させ、特殊文字をOutputの文末に追加することで音声認識をリセットする。
## スクリーンショット（あれば）
<!--UIの変更があれば、この形式で貼り付けてください→<img width=300 src="url">-->

## 備考
<!-- 実装中に発見した仕様など、共有しておきたいこと-->
